### PR TITLE
docs: quaternion wire order is (w, x, y, z); measured clock-factor and dirty_index notes

### DIFF
--- a/L2lidarClass/L2lidar class README.md
+++ b/L2lidarClass/L2lidar class README.md
@@ -107,6 +107,8 @@ Key Features
   * The slow-clock factor is not exactly 2: one unit measured ~1.988 at cold start, drifting to ~1.991 over a 20 minute warm-up (issue #3)
   
   * The first cloud packet(s) after stream start carry `dirty_index` = 100.0 (initialization value; nothing is emitted during the 15 to 30 s motor spin-up); settled clean-unit values are roughly 0.7 median with spikes to about 8
+  
+  * Erratum for the vendor reference doc (READMore.md, kept verbatim from Unitree): its sample output labels the IMU quaternion `(x, y, z, w)`, but the wire order is `(w, x, y, z)`; see issue #2 for the verification
 
 * **Latency Measurement**
   

--- a/L2lidarClass/L2lidar class README.md
+++ b/L2lidarClass/L2lidar class README.md
@@ -102,6 +102,12 @@ Key Features
   
   * Host-driven periodic resynchronization
 
+* **Field notes (fw 2.8.11.1, measured)**
+  
+  * The slow-clock factor is not exactly 2: one unit measured ~1.988 at cold start, drifting to ~1.991 over a 20 minute warm-up (issue #3)
+  
+  * `dirty_index` reads exactly 100.0 during motor spin-up (15 to 30 s, before valid points exist); settled clean-unit values are roughly 0.7 to 1.6 %
+
 * **Latency Measurement**
   
   * RTT latency using sequence IDs

--- a/L2lidarClass/L2lidar class README.md
+++ b/L2lidarClass/L2lidar class README.md
@@ -106,7 +106,7 @@ Key Features
   
   * The slow-clock factor is not exactly 2: one unit measured ~1.988 at cold start, drifting to ~1.991 over a 20 minute warm-up (issue #3)
   
-  * `dirty_index` reads exactly 100.0 during motor spin-up (15 to 30 s, before valid points exist); settled clean-unit values are roughly 0.7 to 1.6 %
+  * The first cloud packet(s) after stream start carry `dirty_index` = 100.0 (initialization value; nothing is emitted during the 15 to 30 s motor spin-up); settled clean-unit values are roughly 0.7 median with spikes to about 8
 
 * **Latency Measurement**
   

--- a/L2lidarClass/include/L2lidar.h
+++ b/L2lidarClass/include/L2lidar.h
@@ -477,6 +477,10 @@ private: // variables
     // L2 Fw Version 2.8.11.1, compile date: 2025-07-30
     // is known to have a timestamp which is slow by
     // a factor 2.0
+    // Bench measurement (see issue #3): on one 2.8.11.1 unit the true
+    // factor was ~1.988 at cold start, drifting to ~1.991 over a
+    // 20 minute warm-up (thermal; imu_temperature settles near 60 C).
+    // Num/Denom can express a measured value, e.g. 1988/1000.
     long long mL2ScaleTimeNum {2};
     long long mL2ScaleTimeDenom {1};
     bool mL2EnableSyncHost = false;

--- a/L2lidarClass/include/unitree_lidar_protocolL2.h
+++ b/L2lidarClass/include/unitree_lidar_protocolL2.h
@@ -343,7 +343,7 @@ typedef struct
 typedef struct 
 {
     DataInfo info;
-    float quaternion[4];             // Quaternion Array.
+    float quaternion[4];             // Quaternion Array (w, x, y, z).
     float angular_velocity[3];       // Three-axis angular velocity values.
     float linear_acceleration[3];    // Three-axis acceleration values.
 }LidarImuData;

--- a/READMore.md
+++ b/READMore.md
@@ -106,13 +106,13 @@ time delay (second) = 0.001880
 An IMU msg is parsed!
     system stamp = 1730191291.3044135571
     seq = 87, stamp = 1730191291.304411172
-    quaternion (x, y, z, w) = [-0.3645, 0.0077, 0.0099, 0.9293]
+    quaternion (w, x, y, z) = [-0.3645, 0.0077, 0.0099, 0.9293]
     angular_velocity (x, y, z) = [0.0209, -0.0644, 0.0146]
     linear_acceleration (x, y, z) = [0.2215, 0.3537, 9.5822]
 An IMU msg is parsed!
     system stamp = 1730191291.3070139885
     seq = 88, stamp = 1730191291.307010650
-    quaternion (x, y, z, w) = [-0.3646, 0.0077, 0.0099, 0.9293]
+    quaternion (w, x, y, z) = [-0.3646, 0.0077, 0.0099, 0.9293]
     angular_velocity (x, y, z) = [0.0086, -0.0039, 0.0122]
     linear_acceleration (x, y, z) = [0.1608, 0.3222, 9.7098]
 A Cloud msg is parsed! 
@@ -165,13 +165,13 @@ time delay (second) = 0.002044
 An IMU msg is parsed!
     system stamp = 1730191291.3044135571
     seq = 87, stamp = 1730191291.304411172
-    quaternion (x, y, z, w) = [-0.3645, 0.0077, 0.0099, 0.9293]
+    quaternion (w, x, y, z) = [-0.3645, 0.0077, 0.0099, 0.9293]
     angular_velocity (x, y, z) = [0.0209, -0.0644, 0.0146]
     linear_acceleration (x, y, z) = [0.2215, 0.3537, 9.5822]
 An IMU msg is parsed!
     system stamp = 1730191291.3070139885
     seq = 88, stamp = 1730191291.307010650
-    quaternion (x, y, z, w) = [-0.3646, 0.0077, 0.0099, 0.9293]
+    quaternion (w, x, y, z) = [-0.3646, 0.0077, 0.0099, 0.9293]
     angular_velocity (x, y, z) = [0.0086, -0.0039, 0.0122]
     linear_acceleration (x, y, z) = [0.1608, 0.3222, 9.7098]
 A Cloud msg is parsed! 

--- a/READMore.md
+++ b/READMore.md
@@ -106,13 +106,13 @@ time delay (second) = 0.001880
 An IMU msg is parsed!
     system stamp = 1730191291.3044135571
     seq = 87, stamp = 1730191291.304411172
-    quaternion (w, x, y, z) = [-0.3645, 0.0077, 0.0099, 0.9293]
+    quaternion (x, y, z, w) = [-0.3645, 0.0077, 0.0099, 0.9293]
     angular_velocity (x, y, z) = [0.0209, -0.0644, 0.0146]
     linear_acceleration (x, y, z) = [0.2215, 0.3537, 9.5822]
 An IMU msg is parsed!
     system stamp = 1730191291.3070139885
     seq = 88, stamp = 1730191291.307010650
-    quaternion (w, x, y, z) = [-0.3646, 0.0077, 0.0099, 0.9293]
+    quaternion (x, y, z, w) = [-0.3646, 0.0077, 0.0099, 0.9293]
     angular_velocity (x, y, z) = [0.0086, -0.0039, 0.0122]
     linear_acceleration (x, y, z) = [0.1608, 0.3222, 9.7098]
 A Cloud msg is parsed! 
@@ -165,13 +165,13 @@ time delay (second) = 0.002044
 An IMU msg is parsed!
     system stamp = 1730191291.3044135571
     seq = 87, stamp = 1730191291.304411172
-    quaternion (w, x, y, z) = [-0.3645, 0.0077, 0.0099, 0.9293]
+    quaternion (x, y, z, w) = [-0.3645, 0.0077, 0.0099, 0.9293]
     angular_velocity (x, y, z) = [0.0209, -0.0644, 0.0146]
     linear_acceleration (x, y, z) = [0.2215, 0.3537, 9.5822]
 An IMU msg is parsed!
     system stamp = 1730191291.3070139885
     seq = 88, stamp = 1730191291.307010650
-    quaternion (w, x, y, z) = [-0.3646, 0.0077, 0.0099, 0.9293]
+    quaternion (x, y, z, w) = [-0.3646, 0.0077, 0.0099, 0.9293]
     angular_velocity (x, y, z) = [0.0086, -0.0039, 0.0122]
     linear_acceleration (x, y, z) = [0.1608, 0.3222, 9.7098]
 A Cloud msg is parsed! 


### PR DESCRIPTION
Documentation-only follow-up to #2 and #3. No code behavior changes.

**What this changes**

1. `READMore.md`: relabels the four IMU sample-output lines from `quaternion (x, y, z, w)` to `quaternion (w, x, y, z)`. The wire order was verified by rotating the same packet's accelerometer vector under all four candidate interpretations (two orders, rotation vs transpose); only (w, x, y, z) body-to-world maps gravity onto the world vertical (0.012 m/s^2 residual vs 1.9 to 16.6 for the others; full table in #2). Your code already consumes it correctly (`Quat.w = Imu.data.quaternion[0]` in L2lidar.cpp), so only the labels needed touching. The relabel is also self-consistent with the existing sample values: `[-0.3645, 0.0077, 0.0099, 0.9293]` read as (w, x, y, z) is a near-pure yaw, matching the sample's near-level accelerometer.
2. `unitree_lidar_protocolL2.h`: notes the order on the `quaternion[4]` field comment.
3. `L2lidar.h`: extends the slow-clock comment with the measured factor (about 1.988 at cold start, drifting to about 1.991 over a 20 minute warm-up on one 2.8.11.1 unit; details and data offer in #3), and notes that Num/Denom can express a measured value such as 1988/1000. The default of 2/1 is left untouched since the exact value appears to be unit and temperature dependent.
4. `L2lidar class README.md`: two short field notes (the clock factor above, and `dirty_index` reading exactly 100.0 during the 15 to 30 s motor spin-up).

Please feel free to reword or trim any of this to match your style. Thanks again for the repo; it has been a great reference.
